### PR TITLE
feat(editor): add JavaFX timeline and drag-drop support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@
  */
 
 // Configure all projects (the root project and all sub-projects)
+plugins {
+    id 'org.openjfx.javafxplugin' version '0.1.0' apply false
+}
+
 allprojects {
     repositories {
         // Use Maven Central for standard dependencies.
@@ -74,9 +78,21 @@ project(':player') {
 
 // Configure the 'editor' sub-project.
 project(':editor') {
+    apply plugin: 'org.openjfx.javafxplugin'
+
     application {
-        // Set the main class for the editor application.
-        mainClass = 'com.dosse.bwentrain.editor.Main'
+        // Launch the JavaFX-based editor entry point.
+        mainClass = 'com.dosse.bwentrain.editor.EditorApp'
+    }
+
+    javafx {
+        version = '21.0.2'
+        modules = [ 'javafx.controls' ]
+    }
+
+    dependencies {
+        // TestFX offers simple integration testing for JavaFX views
+        testImplementation 'org.testfx:testfx-junit5:4.0.16-alpha'
     }
 }
 

--- a/editor/src/main/java/com/dosse/bwentrain/editor/AudioClip.java
+++ b/editor/src/main/java/com/dosse/bwentrain/editor/AudioClip.java
@@ -1,0 +1,46 @@
+package com.dosse.bwentrain.editor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import javax.sound.sampled.*;
+
+/**
+ * Simple representation of an audio clip with a decimated waveform.
+ */
+public class AudioClip {
+    private final File file; // original file reference
+    private final float[] waveform; // normalized waveform samples [-1,1]
+
+    public AudioClip(File file) throws IOException, UnsupportedAudioFileException {
+        this.file = Objects.requireNonNull(file);
+        this.waveform = extractWaveform(file, 1000); // sample 1000 points for display
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public float[] getWaveform() {
+        return waveform;
+    }
+
+    private static float[] extractWaveform(File f, int points)
+            throws IOException, UnsupportedAudioFileException {
+        try (AudioInputStream in = AudioSystem.getAudioInputStream(f)) {
+            AudioFormat fmt = in.getFormat();
+            byte[] data = in.readAllBytes();
+            int frameSize = fmt.getFrameSize();
+            int totalFrames = data.length / frameSize;
+            int step = Math.max(1, totalFrames / points);
+            float[] out = new float[totalFrames / step];
+            for (int i = 0, j = 0; j < out.length && i < data.length; j++, i += step * frameSize) {
+                int idx = i;
+                int sample = fmt.isBigEndian() ? (data[idx] << 8) | (data[idx + 1] & 0xff)
+                        : (data[idx + 1] << 8) | (data[idx] & 0xff);
+                out[j] = sample / 32768f;
+            }
+            return out;
+        }
+    }
+}

--- a/editor/src/main/java/com/dosse/bwentrain/editor/EditorApp.java
+++ b/editor/src/main/java/com/dosse/bwentrain/editor/EditorApp.java
@@ -1,0 +1,26 @@
+package com.dosse.bwentrain.editor;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+/**
+ * Entry point for the JavaFX-based editor.
+ */
+public class EditorApp extends Application {
+    @Override
+    public void start(Stage stage) {
+        TimelineModel model = new TimelineModel();
+        TimelineView view = new TimelineView(model);
+        BorderPane root = new BorderPane(view); // center the timeline
+        Scene scene = new Scene(root, 800, 600);
+        stage.setTitle("SINE Editor");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/editor/src/main/java/com/dosse/bwentrain/editor/TimelineModel.java
+++ b/editor/src/main/java/com/dosse/bwentrain/editor/TimelineModel.java
@@ -1,0 +1,23 @@
+package com.dosse.bwentrain.editor;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.IOException;
+
+/**
+ * Holds audio clips dropped on the timeline.
+ */
+public class TimelineModel {
+    private final List<AudioClip> clips = new ArrayList<>();
+
+    public void addClip(File file) throws IOException, UnsupportedAudioFileException {
+        clips.add(new AudioClip(file));
+    }
+
+    public List<AudioClip> getClips() {
+        return Collections.unmodifiableList(clips);
+    }
+}

--- a/editor/src/main/java/com/dosse/bwentrain/editor/TimelineView.java
+++ b/editor/src/main/java/com/dosse/bwentrain/editor/TimelineView.java
@@ -1,0 +1,84 @@
+package com.dosse.bwentrain.editor;
+
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.AccessibleRole;
+import java.io.File;
+
+/**
+ * Canvas-based timeline that displays waveforms and accepts drag & drop.
+ */
+public class TimelineView extends StackPane {
+    private final TimelineModel model;
+    private final Canvas canvas = new Canvas();
+
+    public TimelineView(TimelineModel model) {
+        this.model = model;
+        getChildren().add(canvas);
+        setAccessibleRole(AccessibleRole.NODE);
+        setAccessibleText("Audio timeline");
+        setOnDragOver(this::handleDragOver);
+        setOnDragDropped(this::handleDrop);
+        widthProperty().addListener((o, a, b) -> resize());
+        heightProperty().addListener((o, a, b) -> resize());
+    }
+
+    private void handleDragOver(DragEvent e) {
+        if (e.getDragboard().hasFiles()) {
+            e.acceptTransferModes(TransferMode.COPY);
+        }
+        e.consume();
+    }
+
+    private void handleDrop(DragEvent e) {
+        e.getDragboard().getFiles().forEach(this::addFile);
+        e.setDropCompleted(true);
+        e.consume();
+    }
+
+    private void addFile(File f) {
+        try {
+            model.addClip(f);
+            redraw();
+        } catch (Exception ex) {
+            // ignore invalid files for now
+        }
+    }
+
+    private void resize() {
+        canvas.setWidth(getWidth());
+        canvas.setHeight(getHeight());
+        redraw();
+    }
+
+    private void redraw() {
+        GraphicsContext g = canvas.getGraphicsContext2D();
+        g.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
+        double trackHeight = canvas.getHeight() / Math.max(1, model.getClips().size());
+        double y = 0;
+        for (AudioClip clip : model.getClips()) {
+            drawWaveform(g, clip.getWaveform(), y, trackHeight);
+            y += trackHeight;
+        }
+    }
+
+    private void drawWaveform(GraphicsContext g, float[] data, double y, double h) {
+        g.setStroke(Color.DARKBLUE);
+        g.beginPath();
+        double w = canvas.getWidth();
+        for (int i = 0; i < data.length; i++) {
+            double x = i * w / data.length;
+            double sy = y + h / 2 - data[i] * h / 2;
+            if (i == 0) {
+                g.moveTo(x, sy);
+            } else {
+                g.lineTo(x, sy);
+            }
+        }
+        g.stroke();
+    }
+}

--- a/editor/src/test/java/com/dosse/bwentrain/editor/TimelineIntegrationTest.java
+++ b/editor/src/test/java/com/dosse/bwentrain/editor/TimelineIntegrationTest.java
@@ -1,0 +1,40 @@
+package com.dosse.bwentrain.editor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import javax.sound.sampled.*;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for TimelineModel.
+ */
+public class TimelineIntegrationTest {
+    @Test
+    void multiTrackAdditionStoresClips() throws Exception {
+        TimelineModel model = new TimelineModel();
+        model.addClip(createTempWav(440));
+        model.addClip(createTempWav(660));
+        assertEquals(2, model.getClips().size());
+    }
+
+    private File createTempWav(int freq) throws Exception {
+        int sampleRate = 44100;
+        byte[] data = new byte[sampleRate * 2];
+        for (int i = 0; i < sampleRate; i++) {
+            double angle = 2 * Math.PI * freq * i / sampleRate;
+            short val = (short) (Math.sin(angle) * Short.MAX_VALUE);
+            data[i * 2] = (byte) (val & 0xff);
+            data[i * 2 + 1] = (byte) ((val >> 8) & 0xff);
+        }
+        File out = File.createTempFile("clip", ".wav");
+        AudioFormat fmt = new AudioFormat(sampleRate, 16, 1, true, false);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                AudioInputStream ais = new AudioInputStream(bais, fmt, sampleRate)) {
+            AudioSystem.write(ais, AudioFileFormat.Type.WAVE, out);
+        }
+        out.deleteOnExit();
+        return out;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ include 'player', 'editor', 'cli'
 // Define the custom directory for the 'player' sub-project.
 project(':player').projectDir = file('SINE')
 
-// Define the custom directory for the 'editor' sub-project.
-project(':editor').projectDir = file('SINE-Editor')
+// Point the 'editor' sub-project at the modern Gradle source tree.
+project(':editor').projectDir = file('editor')
 
 // The 'cli' project is assumed to be in a directory named 'cli' by convention.


### PR DESCRIPTION
## Summary
- migrate editor to JavaFX entry point and integrate OpenJFX plugin
- implement timeline component rendering audio waveforms with drag-drop
- add integration test verifying multi-track clip handling

## Testing
- `gradle test --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_68b0e86df8388333945a3dee6e917094