### PR TITLE
feat(cli): add batch export for session directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Run `gradle wrapper` to generate it locally or execute tasks directly with a sys
 Run `./gradlew :player:jpackage` to create the player installer and `./gradlew :editor:jpackage` for the editor. Icons are taken from `_SETUP/Windows`.
 Manual packaging scripts in `_SETUP` are deprecated and kept only for reference.
 
+### Command line batch export
+The CLI can convert multiple session files in parallel:
+
+```bash
+SINE-CLI --batch path/to/presets path/to/output mp3
+```
+
+Each preset in `path/to/presets` is rendered to an MP3 file with the same base name in `path/to/output`. The `format` argument may be `mp3`, `wav`, or `flac`; it defaults to `wav`.
+
 ## Screenshots
 ![Screenshot](https://fdossena.com/sine/pc1.png)
 ![Screenshot](https://fdossena.com/sine/pc2.png)

--- a/cli/src/test/java/com/dosse/bwentrain/cli/BatchExportTest.java
+++ b/cli/src/test/java/com/dosse/bwentrain/cli/BatchExportTest.java
@@ -1,0 +1,24 @@
+package com.dosse.bwentrain.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BatchExportTest {
+
+    @Test
+    void exportsAllFilesInDirectory() throws Exception {
+        Path input = Files.createTempDirectory("presets");
+        Path output = Files.createTempDirectory("audio");
+        Files.writeString(input.resolve("a.preset"), "preset");
+        Files.writeString(input.resolve("b.preset"), "preset");
+
+        Main.setExporter((in, out, loop) -> Files.writeString(Path.of(out), "audio"));
+
+        Main.batchExport(input.toString(), output.toString(), 0, "wav");
+
+        assertTrue(Files.exists(output.resolve("a.wav")));
+        assertTrue(Files.exists(output.resolve("b.wav")));
+    }
+}


### PR DESCRIPTION
## Summary
- extend CLI to process a directory of preset files and render audio in parallel via bounded thread pool
- document new batch export mode and formatting options
- cover batch export logic with a JUnit test

## Testing
- `javac -classpath "libs/*" -d /tmp/classes/main $(find cli/src/main/java -name "*.java")`
- `javac -classpath "libs/*:/tmp/classes/main" -d /tmp/classes/test $(find cli/src/test/java -name "*.java")`
- `CP=$(echo libs/*.jar | tr ' ' ':'); java -jar libs/junit-platform-console-standalone-1.10.2.jar execute --class-path "/tmp/classes/main:/tmp/classes/test:$CP" --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_68b0e871e0f48333879ba31356a1b00f